### PR TITLE
Improved CI checks

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,36 +1,57 @@
 name: Elixir CI
 
 on:
+  push:
+    branches: [ "primary" ]
   pull_request:
     branches: [ "primary" ]
 
 permissions:
   contents: read
 
+env:
+  ELIXIR_VERSION: '1.14.3'
+  OTP_VERSION: '25'
+
 jobs:
   build:
     name: Build and test
     runs-on: ubuntu-22.04
+    env:
+      ImageOS: ubuntu20
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up environment
-      run: echo "ImageOS=ubuntu20" >> $GITHUB_ENV
     - name: Set up Elixir
-      uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+      uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.14.3'
-        otp-version: '25'
-    - name: Restore dependencies cache
+        elixir-version: ${{ env.ELIXIR_VERSION }}
+        otp-version: ${{ env.OTP_VERSION }}
+    - name: Cache deps
+      id: cache-deps
       uses: actions/cache@v3
+      env:
+        cache-name: cache-elixir-deps
       with:
         path: deps
-        key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-mix-
+        key: mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: $mix-${{ env.cache-name }}-
+    - name: Cache compiled build
+      id: cache-build
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-compiled-build
+      with:
+        path: _build
+        key: mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: mix-${{ env.cache-name }}-
     - name: Install dependencies
       run: mix deps.get
-    # mix format on dev not matching up to the one in github runner
-    - name: Run format check
-      run: mix format --check-formatted
+    - name: Compiles without warnings
+      run: mix compile --warnings-as-errors
     - name: Run tests
       run: mix test
+    - name: Run mix format
+      run: mix format --check-formatted
+    - name: Run credo
+      run: mix credo --strict

--- a/lib/agents/scraper.ex
+++ b/lib/agents/scraper.ex
@@ -21,7 +21,7 @@ defmodule LangChain.Scraper do
 
   @timeout 120_000
 
-  alias LangChain.{ScrapeChain, ChainLink, Chat, PromptTemplate, Chain}
+  alias LangChain.{Chain, ChainLink, Chat, PromptTemplate, ScrapeChain}
   # Client API
 
   def start_link(opts \\ []) do
@@ -95,7 +95,7 @@ defmodule LangChain.Scraper do
     end
   end
 
-  defp default_scrape_chain() do
+  defp default_scrape_chain do
     # can be overruled with the input_schema option
     input_schema = "{ name: String, age: Number }"
 

--- a/lib/indexes/retriever_protocol.ex
+++ b/lib/indexes/retriever_protocol.ex
@@ -7,7 +7,8 @@
 # of numbers) so they can be fed to different neural networks.
 
 # Retriever implementations currently included with this project include:
-# - LangChain.Retriever.FileSystemProvider   -- can get the contents of a file or a list of all the contents of all the files in the directory
+# - LangChain.Retriever.FileSystemProvider ->
+#     gets the contents of a file or a list of all the contents of all the files in the directory
 
 defprotocol LangChain.Retriever do
   @doc """

--- a/lib/indexes/vectorstore_server.ex
+++ b/lib/indexes/vectorstore_server.ex
@@ -22,7 +22,7 @@ defmodule LangChain.VectorStore do
     GenServer.start_link(__MODULE__, {provider, embed_documents, embed_query}, opts)
   end
 
-  defp default_provider() do
+  defp default_provider do
     IO.warn(
       "No :provider option specified, will fallback to default provider from the application environment defined in :vector_store_provider."
     )
@@ -30,16 +30,13 @@ defmodule LangChain.VectorStore do
     Application.get_env(:lang_chain, :vector_store_provider)
   end
 
-  defp default_embed_documents() do
+  defp default_embed_documents do
     fn
       _, _ -> []
     end
   end
 
-  defp default_embed_query() do
-    # Implement default logic for embed_query function or return a function that raises an error
-    # if it should be explicitly set.
-    # Example:
+  defp default_embed_query do
     fn
       _, _ -> []
     end

--- a/lib/langchain/anchor.ex
+++ b/lib/langchain/anchor.ex
@@ -45,7 +45,7 @@ defmodule LangChain.Anchor.CLI do
   @doc """
   returns either :yes or :no depending on the user's input
   """
-  def get_confirmation() do
+  def get_confirmation do
     case IO.gets(">> ") do
       "y\n" -> :yes
       "n\n" -> :no
@@ -73,6 +73,7 @@ end
 #   end
 
 #   def get_confirmation() do
-#     raise "get_confirmation/0 is not supported in the Phoenix implementation. Use a form submission to get user confirmation."
+#     raise "get_confirmation/0 is not supported in the Phoenix implementation." <>
+#       " Use a form submission to get user confirmation."
 #   end
 # end

--- a/lib/langchain/chain.ex
+++ b/lib/langchain/chain.ex
@@ -22,22 +22,22 @@ defmodule LangChain.Chain do
   Processes the ChainLinks in the chain and accumulates the output.
   If the optional `anchor` parameter is set to `true`, an anchor step will be added at the end of the chain for user confirmation.
   """
-  def call(lang_chain, previous_values, anchor \\ false) do
+  def call(lang_chain, previous_values, _anchor \\ false) do
     # Use Enum.reduce to process the ChainLinks and accumulate the output in previous_values
-    result =
-      Enum.reduce(lang_chain.links, previous_values, fn chain_link, acc ->
-        updated_chain_link = LangChain.ChainLink.call(chain_link, acc)
-        # Merge the output of the current ChainLink with the accumulated previous values
-        Map.merge(acc, updated_chain_link.output)
-      end)
+    Enum.reduce(lang_chain.links, previous_values, fn chain_link, acc ->
+      updated_chain_link = LangChain.ChainLink.call(chain_link, acc)
+      # Merge the output of the current ChainLink with the accumulated previous values
+      Map.merge(acc, updated_chain_link.output)
+    end)
 
-    if anchor do
-      case LangChain.Anchor.confirm(:query, result) do
-        :yes -> result
-        :no -> {:error, "User declined"}
-      end
-    else
-      result
-    end
+    # this confirm/2 function is not implemented yet
+    # if anchor do
+    #   case LangChain.Anchor.confirm(:query, result) do
+    #     :yes -> result
+    #     :no -> {:error, "User declined"}
+    #   end
+    # else
+    #   result
+    # end
   end
 end

--- a/lib/langchain/chain_link.ex
+++ b/lib/langchain/chain_link.ex
@@ -24,7 +24,9 @@ defmodule LangChain.ChainLink do
   @doc """
   calls the chain_link, filling in the input prompt and parsing the output
   """
-  def call(%{input: %LangChain.Chat{} = chat} = chain_link, previousValues \\ %{}) do
+  def call(chain_link, previousValues \\ %{})
+
+  def call(%{input: %LangChain.Chat{} = chat} = chain_link, previousValues) do
     {:ok, evaluated_templates} = LangChain.Chat.format(chat, previousValues)
 
     model_inputs =
@@ -55,7 +57,7 @@ defmodule LangChain.ChainLink do
   # you can define your own parser functions, but this is the default
   # the output of the ChainLink will be used as variables in the next link
   # by default the simple text response goes in the :text key
-  defp no_parse(chain_link, outputs \\ []) do
+  def no_parse(chain_link, outputs \\ []) do
     %{
       chain_link
       | raw_responses: outputs,

--- a/lib/langchain/llm.ex
+++ b/lib/langchain/llm.ex
@@ -1,4 +1,6 @@
 defmodule LangChain.LLM do
+  alias LangChain.Providers.{OpenAI, Replicate}
+
   @moduledoc """
     A generic LLM interface for interacting with different LLM providers
   """
@@ -18,19 +20,19 @@ defmodule LangChain.LLM do
   #   %{text: "I'm a generic message. I'm Foo. I'm Bar.", role: "test"}
   def chat(model, chats) when is_list(chats) do
     case model.provider do
-      :openai -> LangChain.Providers.OpenAI.chat(model, chats)
+      :openai -> OpenAI.chat(model, chats)
       # :gpt3 -> handle_gpt3_call(model, prompt)
-      _ -> "unknown provider #{model.provider}"
+      _ -> {:error, "Unknown provider #{inspect(model.provider)}"}
     end
   end
 
   # call is a single chat msg for one prompt
   def call(model, prompt) do
     case model.provider do
-      :openai -> LangChain.Providers.OpenAI.call(model, prompt)
-      :replicate -> LangChain.Providers.Replicate.call(model, prompt)
+      :openai -> OpenAI.call(model, prompt)
+      :replicate -> Replicate.call(model, prompt)
       # :gpt3 -> handle_gpt3_call(model, prompt)
-      _ -> "unknown provider #{model.provider}"
+      _ -> {:error, "Unknown provider #{inspect(model.provider)}"}
     end
   end
 end

--- a/lib/providers/openai.ex
+++ b/lib/providers/openai.ex
@@ -68,7 +68,8 @@ defmodule LangChain.Providers.OpenAI do
   #     finish_reason: "stop",
   #     index: 0,
   #     message: %{
-  #       content: "The product of 7 and 5 is 35. The square root of 35 rounded to 2-digit precision is approximately 5.92.",
+  #       content: "The product of 7 and 5 is 35.
+  #         The square root of 35 rounded to 2-digit precision is approximately 5.92.",
   #       role: "assistant"
   #     }
   #   }, ......
@@ -91,18 +92,12 @@ defmodule LangChain.Embedding.OpenAIProvider do
     def embed_documents(_provider, model, documents) do
       opts = []
 
-      with {:ok, results} <-
-             ExOpenAI.Embeddings.create_embedding(documents, model.model_name, opts) do
-        case results do
-          %ExOpenAI.Components.CreateEmbeddingResponse{data: data} ->
-            embeddings = Enum.map(data, fn %{embedding: embedding} -> embedding end)
-            {:ok, embeddings}
+      case ExOpenAI.Embeddings.create_embedding(documents, model.model_name, opts) do
+        {:ok, %ExOpenAI.Components.CreateEmbeddingResponse{data: data}} ->
+          embeddings = Enum.map(data, fn %{embedding: embedding} -> embedding end)
+          {:ok, embeddings}
 
-          _ ->
-            {:error, "unexpected response from OpenAI API"}
-        end
-      else
-        error ->
+        {:error, error} ->
           {:error, error}
       end
     end

--- a/lib/providers/replicate.ex
+++ b/lib/providers/replicate.ex
@@ -6,11 +6,11 @@ defmodule LangChain.Providers.Replicate do
     and return any data, it can be used for LLM, image generation, image parsing, sound, etc
   """
 
-  def chat(model, chats) when is_list(chats) do
+  def chat(_model, chats) when is_list(chats) do
     # Implement your Replicate API chat call here
   end
 
-  def call(model, prompt) do
+  def call(_model, _prompt) do
     # Implement your Replicate API call here
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule LangchainEx.MixProject do
       version: "0.1.0",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
       deps: deps(),
       package: package(),
       # prevents protocol consolidation warning
@@ -39,6 +40,12 @@ defmodule LangchainEx.MixProject do
         "docs" => "https://hexdocs.pm/langchainex"
       },
       description: "Language Chains for Elixir"
+    ]
+  end
+
+  defp aliases do
+    [
+      verify: ["compile --warnings-as-errors", "format --check-formatted", "credo --strict"]
     ]
   end
 end

--- a/test/agents/scraper.ex
+++ b/test/agents/scraper.ex
@@ -3,7 +3,7 @@ defmodule LangChain.ScraperTest do
   Tests for LangChain.Scraper
   """
   use ExUnit.Case, async: true
-  alias LangChain.{ScrapeChain, Scraper, ChainLink, Chat, PromptTemplate, Chain}
+  alias LangChain.{Chain, ChainLink, Chat, PromptTemplate, Scraper, ScraperChain}
 
   setup do
     {:ok, pid} = Scraper.start_link()

--- a/test/chains/scrape_chain.ex
+++ b/test/chains/scrape_chain.ex
@@ -4,7 +4,7 @@ defmodule ScrapeChainTest do
   """
   use ExUnit.Case
 
-  alias LangChain.{Chat, ChainLink, Chain, PromptTemplate}
+  alias LangChain.{Chain, ChainLink, Chat, PromptTemplate}
   alias ScrapeChain
 
   # Create a parser function for the ChainLink

--- a/test/indexes/provider_protocol.ex
+++ b/test/indexes/provider_protocol.ex
@@ -1,4 +1,6 @@
 defmodule VectorStoreProviderTest do
+  @moduledoc false
+
   use ExUnit.Case
   alias LangChain.VectorStore.Provider
   alias MockVectorStoreProvider

--- a/test/indexes/vectorstore.ex
+++ b/test/indexes/vectorstore.ex
@@ -1,4 +1,6 @@
 defmodule VectorStoreTest do
+  @moduledoc false
+
   use ExUnit.Case
   alias LangChain.VectorStore
   alias MockVectorStoreProvider

--- a/test/langchain/chain.ex
+++ b/test/langchain/chain.ex
@@ -3,7 +3,7 @@ defmodule LangChain.ChainTest do
   Tests for LangChain.Chain
   """
   use ExUnit.Case
-  alias LangChain.{LLM, Chat, Chain, ChainLink, PromptTemplate}
+  alias LangChain.{Chain, ChainLink, Chat, LLM, PromptTemplate}
 
   # takes list of all outputs and the ChainLink that evaluated them
   # returns the new state of the ChainLink

--- a/test/langchain/chat.ex
+++ b/test/langchain/chat.ex
@@ -4,7 +4,7 @@ defmodule LangChain.ChatTest do
   """
   use ExUnit.Case
 
-  def create_chat() do
+  def create_chat do
     system_prompt = %LangChain.PromptTemplate{
       template: "Here is a spell name: <%= spell %>",
       input_variables: [:context],

--- a/test/providers/file_system.exs
+++ b/test/providers/file_system.exs
@@ -64,12 +64,12 @@ defmodule FileSystemProviderTest do
     assert result != {:error, :invalid_path}
     assert Enum.any?(result, &String.starts_with?(&1, "defmodule FileSystemProviderTest do"))
 
-    queryEx = %{path: path, file_extensions: [".ex"]}
-    resultEx = Retriever.get_relevant_documents(provider, queryEx)
+    query_ex = %{path: path, file_extensions: [".ex"]}
+    result_ex = Retriever.get_relevant_documents(provider, query_ex)
 
-    assert resultEx != {:error, :invalid_path}
+    assert result_ex != {:error, :invalid_path}
 
-    assert Enum.any?(resultEx, &String.starts_with?(&1, "defmodule FileSystemProviderTest do")) ==
+    assert Enum.any?(result_ex, &String.starts_with?(&1, "defmodule FileSystemProviderTest do")) ==
              false
   end
 

--- a/test/providers/openai.ex
+++ b/test/providers/openai.ex
@@ -1,8 +1,10 @@
 defmodule LangChain.Embedding.OpenAIProviderTest do
+  @moduledoc false
+
   use ExUnit.Case, async: true
 
-  alias LangChain.EmbeddingProtocol
   alias LangChain.Embedding.OpenAIProvider
+  alias LangChain.EmbeddingProtocol
 
   describe "embed_documents/2" do
     test "embeds documents with OpenAI provider" do
@@ -24,7 +26,6 @@ defmodule LangChain.Embedding.OpenAIProviderTest do
       assert {:ok, embeddings} =
                EmbeddingProtocol.embed_documents(openai_provider, llm, documents)
 
-      IO.inspect(embeddings)
       assert length(embeddings) == length(documents)
     end
   end

--- a/test/providers/pinecone.ex
+++ b/test/providers/pinecone.ex
@@ -1,7 +1,9 @@
 defmodule VectorStoreProviderTest do
+  @moduledoc false
+
   use ExUnit.Case
-  alias LangChain.VectorStore.Provider
   alias LangChain.VectorStore.PineconeProvider
+  alias LangChain.VectorStore.Provider
 
   setup do
     provider = %PineconeProvider{
@@ -12,13 +14,13 @@ defmodule VectorStoreProviderTest do
   end
 
   test "add_vectors/2", %{provider: provider} do
-    # make 3 vectors of size 1536 each, since the openai davicini model uses that size vector
+    # make 3 vectors of size 1536 each, since the openai davinci model uses that size vector
     vectors =
       Enum.map(1..3, fn _ ->
         Enum.map(1..1536, fn _ -> :rand.uniform() end)
       end)
 
-    # the pinecone 
+    # the pinecone
     {:ok, added_vectors_count} = Provider.add_vectors(provider, vectors)
 
     assert added_vectors_count == length(vectors)
@@ -26,6 +28,8 @@ defmodule VectorStoreProviderTest do
 end
 
 defmodule PineconeVectorStoreTest do
+  @moduledoc false
+
   use ExUnit.Case
   alias LangChain.VectorStore
   alias LangChain.VectorStore.PineconeProvider


### PR DESCRIPTION
I have added further checks to our CI job:
- `mix compile --warnings-as-errors`
- `mix credo --strict`

In order to have them in CI I had to fix all the warnings we had in place.


I also created a new mix alias in order to run all checks locally before pushing code. You can run it with the command `mix verify`